### PR TITLE
Update index.md

### DIFF
--- a/projekte/WeNoM/index.md
+++ b/projekte/WeNoM/index.md
@@ -24,15 +24,10 @@ In der /etc/apache2/apache2.conf ergänzen:
 
 ```bash
 <Directory /var/www/html/>	
-        Options Indexes FollowSymLinks Includes ExecCGI
-        AllowOverride All
+        AllowOverride none
         Require all granted
 </Directory>
 ```
-
-### PDO_SQLite
-
-In der /etc/php/8.X/apache2/php.ini muss unter ``` Dynamic Extension ``` die Zeile ``` extension=pdo_sqlite ``` auskommentiert werden.
 
 ### PHP-Memory-Limit
 


### PR DESCRIPTION
Apache Location Options angepasst. Die sind nicht erforderlich. Durch die Installtion von  php-sqlite3 wird die Erweiterung in /etc/php/8.3/cgi/conf.d/20-pdo_sqlite.ini automatisch aktiviert.